### PR TITLE
Use library(crypto) for computing the hash.

### DIFF
--- a/download.pl
+++ b/download.pl
@@ -42,6 +42,7 @@
 :- use_module(library(error)).
 :- use_module(library(filesex)).
 :- use_module(library(persistency)).
+:- use_module(library(crypto)).
 :- use_module(wiki).
 
 %%	download(+Request) is det.
@@ -707,13 +708,5 @@ file_checksum(Path, Sum) :-
 	sha256(Path, Sum0), !,
 	Sum = Sum0.
 file_checksum(Path, Sum) :-
-	setup_call_cleanup(
-	    process_create('/usr/bin/sha256sum', ['-b', file(Path)],
-			   [ stdout(pipe(Out)) ]),
-	    read_string(Out, _, Line),
-	    close(Out)),
-	split_string(Line, " ", " ", [Hash|_]),
-	atom_string(Sum0, Hash),
-	assert_sha256(Path, Sum0),
-	Sum = Sum0.
-
+	crypto_file_hash(Path, Sum, [encoding(octet)]),
+	assert_sha256(Path, Sum).


### PR DESCRIPTION
The fact that this is slower for very large files does not really
matter in this case, since the hash is only computed once per file.
It is much more important to stress the functionality of SWI-Prolog,
and this acts as an automatic test case for the OpenSSL bindings
in addition to being shorter and more portable.

This is the first step towards signatures via library(crypto).