### PR TITLE
Change Freenode IRC link to Libera.Chat

### DIFF
--- a/page.pl
+++ b/page.pl
@@ -537,7 +537,7 @@ menu(Style,
 	 ]
        ],
        'Community' =           '/community.html' +
-       [ 'IRC'                 = 'http://webchat.freenode.net/?channels=##prolog',
+       [ 'IRC'                 = 'https://web.libera.chat/?channels=##prolog',
 	 'Forum & mailing list'= 'https://swi-prolog.discourse.group',
 	 'Blog'                = '/blog',
 	 'News'                = '/news/archive',


### PR DESCRIPTION
tl;dr Freenode was taken over and most staff moved to Libera.Chat.

- https://en.wikipedia.org/wiki/Freenode#Ownership_change_and_conflict
- https://arstechnica.com/gadgets/2021/05/freenode-irc-has-been-taken-over-by-the-crown-prince-of-korea/
- https://www.jeffgeerling.com/blog/2021/freenode-dead-long-live-irc